### PR TITLE
Docker ngnix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This project is built with React, Redux, Typescript, Recharts on the frontend and FastAPI, Gensim, Elasticsearch on the backend. 
 
+- [Grant Explorer](#grant-explorer)
+- [Building](#building)
+	- [Frontend](#frontend)
+	- [Backend](#backend)
+- [Docker](#docker)
+- [Contributing](#contributing)
+
 # Building
 
 ## Frontend
@@ -9,6 +16,19 @@ This project is built with React, Redux, Typescript, Recharts on the frontend an
 
 ## Backend
 `poetry install && poetry run python app.py`
+
+
+# Docker
+
+In the base directory, run:
+
+```
+docker-compose up --build
+```
+
+The app will be served at `http://localhost:8080`
+
+This needs the elasticsearch data to be available in directory: `./elasticsearch_data`.
 
 
 # Contributing

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,8 @@ RUN poetry config virtualenvs.create false \
 # Copy over the source code
 COPY . .
 
+# RUN poetry run python app.py --generate-openapi-json ./api.json
+
 EXPOSE 8888
 
 # Kick things off

--- a/backend/app.py
+++ b/backend/app.py
@@ -71,7 +71,7 @@ def main(toggle='any', terms=default_terms):
     if type(terms) is str:
         terms = terms.split(',')
 
-    with open('static/divisions.csv', 'r') as divs:
+    with open('assets/divisions.csv', 'r') as divs:
         divisions = [{
                 'title': d.strip()[:-2],
                 'default': d.strip()[-1] == 'y'
@@ -230,4 +230,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
     with open('api.json', 'w') as api:
         json.dump(app.openapi(), api)
-    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)
+    dev_mode = os.environ.get('DEV_MODE')
+    if dev_mode:
+        uvicorn.run("app:app", host=args.host, port=args.port, log_level=args.log_level, reload=True)
+    else:
+        uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)

--- a/backend/app.py
+++ b/backend/app.py
@@ -219,7 +219,7 @@ async def get_abstract(_id, terms):
 
 
 @app.get('/generate_openapi_json')
-def send_api_json():
+async def send_api_json():
     return app.openapi()
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -218,6 +218,11 @@ async def get_abstract(_id, terms):
     return await Q.abstract(aioes, _id, terms)
 
 
+@app.get('/generate_openapi_json')
+def send_api_json():
+    return app.openapi()
+
+
 app.mount('/data', app)
 
 if __name__ == '__main__':

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
             # makes debugging easier.
             - PYTHONUNBUFFERED=1
             - LOG_LEVEL=DEBUG
+            - DEV_MODE=1
             - ELASTICSEARCH_HOST=elasticsearch
         # command: ["main:app", "--host", "0.0.0.0", "--reload"]
         ports:
@@ -27,13 +28,13 @@ services:
             - ELASTICSEARCH_HOST=elasticsearch
         ports:
             - 3000:3000
-    # proxy:
-    #     build: ./proxy
-    #     ports:
-    #         - 8080:80
-    #     depends_on:
-    #         - frontend
-    #         - backend
+    proxy:
+        build: ./proxy
+        ports:
+            - 8080:80
+        depends_on:
+            - frontend
+            - backend
     elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
         volumes: 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,10 @@ services:
             - ./frontend/package.json:/usr/local/src/app/frontend/package.json
             - ./frontend/tsconfig.json:/usr/local/src/app/frontend/tsconfig.json
             - ./frontend/yarn.lock:/usr/local/src/app/frontend/yarn.lock
+            # We don't want to mount the codegen-generated api directory since it will
+            # be generated in Docker, so specify it as a persistent Docker named volume:
+            # https://stackoverflow.com/a/38601156
+            - docker_openapi:/usr/local/src/app/frontend/src/api
         environment: 
             - ELASTICSEARCH_HOST=elasticsearch
         ports:
@@ -46,3 +50,5 @@ services:
         ports: 
             - 9200:9200
             - 9300:9300
+volumes:
+    docker_openapi:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
             - ELASTICSEARCH_HOST=elasticsearch
         ports:
             - 3000:3000
+        depends_on: 
+            - backend
     proxy:
         build: ./proxy
         ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,8 @@ RUN yarn install --network-timeout 100000
 # Copy in the source code
 COPY . .
 
+# RUN npx openapi-typescript-codegen --input ../backend/api.json --output ./src/api
+
 # This tells build scripts and libraries that we're in development, so they
 # can include stuff that's helpful for debugging even if it's a tad slower.
 ARG NODE_ENV=development
@@ -26,4 +28,4 @@ RUN yarn build
 EXPOSE 3000
 
 ENTRYPOINT [ "yarn" ]
-CMD [ "start" ]
+CMD [ "generateAndStart" ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.3.0",
         "material-ui-chip-input": "^1.1.0",
+        "node-fetch": "^2.6.1",
         "query-string": "^6.5.0",
         "react": "^17.0.2",
         "react-debounce-input": "^3.2.0",
@@ -39,6 +40,7 @@
     "scripts": {
         "start": "react-scripts start",
         "build": "react-scripts build",
+        "generateAndStart": "node ./scripts/generateAPI.js && yarn start",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "lint": "eslint . --ext .ts,.tsx"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.3.0",
         "material-ui-chip-input": "^1.1.0",
-        "node-fetch": "^2.6.1",
         "query-string": "^6.5.0",
         "react": "^17.0.2",
         "react-debounce-input": "^3.2.0",
@@ -67,6 +66,7 @@
         "@typescript-eslint/parser": "^4.29.0",
         "eslint": "^7.32.0",
         "eslint-plugin-react": "^7.24.0",
+        "node-fetch": "^2.6.1",
         "openapi-typescript-codegen": "^0.9.3"
     }
 }

--- a/frontend/scripts/generateAPI.js
+++ b/frontend/scripts/generateAPI.js
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const OpenAPI = require('openapi-typescript-codegen');
+const fetch = require('node-fetch');
+
+// async function fetchUntilSucceeded() {
+//   let success = false;
+//   while(!success) {
+//     try {
+//       let result = await fetch('http://localhost/data/generate_openapi_json');
+//       success = true;
+//       return result;
+//     } catch {
+//       setTimeout();
+//     }
+//   }
+// }
+
+function wait(delay){
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+function fetchRetry(url, delay, tries, fetchOptions = {}) {
+  function onError(err){
+    triesLeft = tries - 1;
+    if(!triesLeft){
+      throw err;
+    }
+    return wait(delay).then(() => fetchRetry(url, delay, triesLeft, fetchOptions));
+  }
+  return fetch(url,fetchOptions).catch(onError);
+}
+
+
+fetchRetry('http://backend:8888/data/generate_openapi_json', 1000, 100)
+  .then((res) => res.json())
+  .then((res) => {
+
+    OpenAPI.generate({
+      input: res,
+      output: './src/api'
+    });
+  });

--- a/frontend/src/api/core/OpenAPI.ts
+++ b/frontend/src/api/core/OpenAPI.ts
@@ -17,7 +17,7 @@ type Config = {
 }
 
 export const OpenAPI: Config = {
-    BASE: 'http://localhost:8888/data',
+    BASE: 'http://localhost:8080/data',
     VERSION: '0.1.0',
     WITH_CREDENTIALS: false,
     TOKEN: undefined,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8387,6 +8387,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,4 +5,4 @@ COPY nginx.conf /etc/nginx/nginx.conf
 ARG CONF_FILE=local.conf
 COPY $CONF_FILE /etc/nginx/conf.d/default.conf
 
-COPY dist /var/www/ui/
+COPY dist /var/www/frontend/

--- a/proxy/local.conf
+++ b/proxy/local.conf
@@ -7,18 +7,18 @@ server {
     expires -1;
 
     location / {
-        proxy_pass http://ui:3000;
+        proxy_pass http://frontend:3000;
     }
 
     # This allows a websocket connection between the client and the webpack development server,
     # so that webpack can reload the developer's browser after they make changes.
     location /sockjs-node {
-        proxy_pass http://ui:3000;
+        proxy_pass http://frontend:3000;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
     }
 
-    location /api {
-        proxy_pass http://api:8000;
+    location /data {
+        proxy_pass http://backend:8888;
     }
 }


### PR DESCRIPTION
- Add ngnix proxying to docker-compose, so that both backend and frontend traffic use the same `localhost` port (8080). 
- Run codegen to generate the frontend `api` directory in docker at runtime.

This shouldn't break anything if you're not using docker.