### PR TITLE
Docker frontend build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ frontend/node_modules
 
 # production
 /build
+frontend/build
 
 # misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ frontend/node_modules
 # production
 /build
 frontend/build
+deploy
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project is built with React, Redux, Typescript, Recharts on the frontend an
 	- [Frontend](#frontend)
 	- [Backend](#backend)
 - [Docker](#docker)
+	- [Deploying (with Docker)](#deploying-with-docker)
 - [Contributing](#contributing)
 
 # Building
@@ -31,6 +32,33 @@ docker-compose --compatibility up --build
 The app will be served at `http://localhost:8080`
 
 This needs the elasticsearch data to be available in directory: `./elasticsearch_data`.
+
+## Deploying (with Docker)
+
+```
+# build the frontend
+docker-compose run frontend build
+
+# save the frontend-prod image and the backend image
+docker-compose -f docker-compose-prod.yaml build frontend-prod \
+  && docker save -o deploy/nsf-viz_frontend-prod.docker.tar nsf-viz_frontend-prod \
+  && docker save -o deploy/nsf-viz_backend.docker.tar nsf-viz_backend
+
+# upload the two images to the server
+scp -r deploy <address_and_path_to_server>
+
+
+# run the following commands on the server
+
+# load the docker images
+docker load -i deploy/nsf-viz_frontend-prod.docker.tar \
+  && docker load -i deploy/nsf-viz_backend.docker.tar
+
+# start all the containers
+docker-compose -f docker-compose-prod.yaml --compatibility up
+```
+
+The app will be served on port 8080.
 
 
 # Contributing

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -4,6 +4,7 @@
 .dockerignore
 
 venv
+assets
 
 # Docker artifacts
 Dockerfile

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -25,7 +25,10 @@ services:
         depends_on: 
             - backend
     proxy:
-        build: ./proxy
+        build: 
+            context: ./proxy
+            args:
+                CONF_FILE: prod.conf
         ports:
             - 8080:80
         depends_on:

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -29,7 +29,7 @@ services:
         ports:
             - 8080:80
         depends_on:
-            - frontend
+            - frontend-prod
             - backend
     elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -14,21 +14,10 @@ services:
         # command: ["main:app", "--host", "0.0.0.0", "--reload"]
         # ports:
         #     - 8888:8888
-    frontend:
-        build: ./frontend
-        # We can't mount the entire UI directory, since JavaScript dependencies
-        # (`node_modules`) live at that location.
-        volumes:
-            - ./frontend/src:/usr/local/src/app/frontend/src
-            - ./frontend/public:/usr/local/src/app/frontend/public
-            - ./frontend/build:/usr/local/src/app/frontend/build
-            - ./frontend/package.json:/usr/local/src/app/frontend/package.json
-            - ./frontend/tsconfig.json:/usr/local/src/app/frontend/tsconfig.json
-            - ./frontend/yarn.lock:/usr/local/src/app/frontend/yarn.lock
-            # We don't want to mount the codegen-generated api directory since it will
-            # be generated in Docker, so specify it as a persistent Docker named volume:
-            # https://stackoverflow.com/a/38601156
-            - docker_openapi:/usr/local/src/app/frontend/src/api
+    frontend-prod:
+        build: 
+            context: ./frontend
+            dockerfile: Dockerfile-prod
         environment: 
             - ELASTICSEARCH_HOST=elasticsearch
         # ports:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -9,7 +9,7 @@ Dockerfile
 node_modules/
 
 # UI build output
-build/
+# build/
 
 # UI package manager debug output
 *.log

--- a/frontend/Dockerfile-prod
+++ b/frontend/Dockerfile-prod
@@ -1,0 +1,15 @@
+FROM node:14.16-slim
+
+WORKDIR /usr/local/src/app/frontend
+
+RUN yarn global add serve
+
+RUN mkdir build
+
+# Copy in the source code
+COPY build build
+
+ENV NODE_ENV $NODE_ENV
+
+ENTRYPOINT [ "serve" ]
+CMD [ "-l", "3000", "-s", "build" ]

--- a/proxy/prod.conf
+++ b/proxy/prod.conf
@@ -6,14 +6,11 @@ server {
 
     expires -1;
 
-    root /var/www/skiff/ui/build;
-    index index.html;
-
     location / {
-        try_files $uri /index.html;
+        proxy_pass http://frontend-prod:3000;
     }
 
-    location /api {
-        proxy_pass http://localhost:8000;
+    location /data {
+        proxy_pass http://backend:8888;
     }
 }


### PR DESCRIPTION
Method of deployment on a server that drastically reduces the memory and storage requirements. Instead of building the frontend on the server, build a static version on a different machine, then save a Docker image that just serves this static version, which can be deployed on the server. See the README for details.