### PR TITLE
Backend queries refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ scp -r deploy <address_and_path_to_server>
 docker load -i deploy/nsf-viz_frontend-prod.docker.tar \
   && docker load -i deploy/nsf-viz_backend-prod.docker.tar
 
+# may be necessary to change permissions on `elasticsearch_data` directory
+sudo chown -R elasticsearch:elasticsearch elasticsearch_data/ \
+  && sudo chmod -R a+w elasticsearch_data/
+
 # start all the containers
 docker-compose -f docker-compose-prod.yaml --compatibility up
 ```

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,3 +5,4 @@ assets/*
 !assets/README*
 api.json
 api*.json
+*.log

--- a/backend/app.py
+++ b/backend/app.py
@@ -186,7 +186,8 @@ async def grant_data(request: GrantsRequest):
         
 
 @app.get('/abstract/{_id}/{terms}', operation_id='loadAbstract', response_model=str)
-async def get_abstract(_id, terms):
+@app.get('/abstract/{_id}/', operation_id='loadAbstract', response_model=str)
+async def get_abstract(_id, terms=""):
     return await Q.abstract(aioes, _id, terms)
 
 

--- a/backend/queries.py
+++ b/backend/queries.py
@@ -201,7 +201,6 @@ async def division_aggregates(
     per_year_buckets = hits['aggregations']['years']['buckets']
     # TODO better way to merge these
     # overall_buckets = hits['aggregations']['key1']['buckets']
-    # overall_buckets = hits['aggregations']['key1']['buckets']
     # overall_buckets2 = hits['aggregations']['key2']['buckets']
     overall_buckets = hits['aggregations']['cat1']['buckets']
 
@@ -260,7 +259,7 @@ async def grants(aioes,
                     'bool': {
                         'should': [{
                             'term': {
-                                'cat1': div
+                                'cat1': div,
                             }
                         } for div in divisions]
                     }
@@ -339,7 +338,7 @@ async def abstract(aioes, _id: str, terms: str):
 
  
 async def typeahead(aioes, prefix: str):
-    result = await aioes.search(index='nsf-suggest', body={
+    result = await aioes.search(index=INDEX_SUGGEST, body={
             'suggest': {
                 'gram-suggest': {
                     'prefix': prefix,


### PR DESCRIPTION
Copy the refactored `queries.py` file from the `hierarchical-divisions` branch, then make the necessary changes to work with the newer data model. Still non-hierarchical at this point (only using `cat1`). We'll need to make changes to make use of hierarchical categories.

This should fix the errors when there are no terms selected.

Also, a few minor cleanup edits.