### PR TITLE
bugfix: allow multiple terms for abstract request

### DIFF
--- a/frontend/src/app/actions.ts
+++ b/frontend/src/app/actions.ts
@@ -98,7 +98,7 @@ export const loadAbstract = createAsyncThunk<
     if (selected.length) {
       terms = selected;
     }
-    return await Service.loadAbstract(payload, terms);
+    return await Service.loadAbstract(payload, terms.join(','));
   }
 );
 


### PR DESCRIPTION
Small edit to get the abstract api request working when there are multiple terms.

We might want to revisit this API request later. There seem to be several different ways we're forming the requests; maybe we could unify them. Also, we might want to change from using the query-string library to using URLSearchParams API, since the former is being deprecated.