### PR TITLE
load an empty Word2Vec instance if the model file is missing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -50,7 +50,11 @@ async def startup():
     ASSETS_DIR = os.environ.get('ASSETS_DIR', 'assets')
     ASSETS_DIR = Path(ASSETS_DIR)
     path_to_model = ASSETS_DIR.joinpath('nsf_w2v_model')
-    word_vecs = Word2Vec.load(str(path_to_model)).wv
+    try:
+        word_vecs = Word2Vec.load(str(path_to_model)).wv
+    except FileNotFoundError:
+        logger.warning(f"No such file or directory: '{path_to_model}'. Skipping loading Word2Vec model")
+        word_vecs = Word2Vec()
     logger.error(f"logLevel: {logger.level}")
     logger.error(f"root logLevel: {root_logger.level}")
     logger.error('error logger')

--- a/frontend/scripts/generateAPI.js
+++ b/frontend/scripts/generateAPI.js
@@ -22,7 +22,7 @@ function wait(delay){
 
 function fetchRetry(url, delay, tries, fetchOptions = {}) {
   function onError(err){
-    triesLeft = tries - 1;
+    const triesLeft = tries - 1;
     if(!triesLeft){
       throw err;
     }


### PR DESCRIPTION
Small change to allow the app to start up even if the Word2Vec model files are missing. The app won't work in this case, but it's useful for testing to know if the backend and frontend will start without errors.

To run this test, clone a fresh version of the repository:

```sh
git clone <path_to_nsf-viz> nsf-viz-cleantest
cd nsf-viz-cleantest
docker-compose up --build
```

The elasticsearch container will fail, but the other ones should start up without errors.