### PR TITLE
implement download grants as csv

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -81,6 +81,7 @@ class Grant(BaseModel):
     title: str
     date: str
     amount: int
+    abstract: Optional[str] = None
     cat1: str
     cat1_raw: str
     cat2: Optional[str]

--- a/frontend/src/app/chart/Chart.tsx
+++ b/frontend/src/app/chart/Chart.tsx
@@ -139,6 +139,7 @@ const Chart = (props: ChartProps) => {
 
   // query backend on query change
   useEffect(() => {
+    console.log('loading');
     dispatch(loadData(query));
   }, [JSON.stringify([selectedTerms.length ? selectedTerms : query.terms, query.org, query.intersection, query.start, query.end ])]);
 

--- a/frontend/src/app/grants/GrantsDialog.tsx
+++ b/frontend/src/app/grants/GrantsDialog.tsx
@@ -22,6 +22,7 @@ import AbstractDialog from './AbstractDialog';
 import { cols, GrantColumn, GrantListItem } from './GrantRow';
 import GrantsTable from './GrantsTable';
 import FilterChip from './FilterChip';
+import useGrantsDownload from './grantsDownload';
 
 const ProgressBar = styled(LinearProgress)`
   margin-bottom: -4px;
@@ -40,6 +41,7 @@ export const GrantListHeader = styled(GrantListItem)<GrantListHeaderStyles>(({ t
 const GrantsDialog = () => {
 
   const [ query, setQuery ] = useQuery();
+  const handleDownloadGrants = useGrantsDownload();
 
   useEffect(() => {
     dispatch(clearGrants());
@@ -60,11 +62,11 @@ const GrantsDialog = () => {
   }, [query.grantDialogOpen, numGrants]);
 
   const handleSort = (property: keyof Grant) => () => {
-    const direction = query.grantOrder === property
+    const direction = query.grantSort === property
       && query.grantDirection === 'asc' ? 'desc' : 'asc';
 
     setQuery({
-      grantOrder: property,
+      grantSort: property,
       grantDirection: direction,
     });
     dispatch(clearGrants());
@@ -77,10 +79,6 @@ const GrantsDialog = () => {
       divisions: query.grantDialogDivision ? [query.grantDialogDivision] : query.divisions,
       idx: 0,
     }));
-  };
-
-  const handleDownload = () => {
-    window.alert('coming soon');
   };
 
   const handleClose = () => {
@@ -122,7 +120,7 @@ const GrantsDialog = () => {
             <GrantColumn key={id} column={id}>
               <Box position='relative' width='100%'>
                 <TableSortLabel
-                  active={query.grantOrder === id}
+                  active={query.grantSort === id}
                   direction={query.grantDirection}
                   onClick={handleSort(id)}
                 >
@@ -143,7 +141,7 @@ const GrantsDialog = () => {
         </Collapse>
         {loading && <ProgressBar />}
         <DialogActions>
-          <Button onClick={handleDownload}>
+          <Button onClick={handleDownloadGrants}>
             Download
           </Button>
           <Button onClick={handleClose}>

--- a/frontend/src/app/grants/GrantsTable.tsx
+++ b/frontend/src/app/grants/GrantsTable.tsx
@@ -31,14 +31,14 @@ const GrantsTable = (props: GrantsTableProps) => {
       grantsRef.current.resetloadMoreItemsCache();
     }
     hasMountedRef.current = true;
-  }, [ query.grantOrder, query.grantDirection, hasMountedRef.current ]);
+  }, [ query.grantSort, query.grantDirection, hasMountedRef.current ]);
 
   const handleLoadGrants = async (idx: number) => {
     if (!loading) {
       await dispatch(loadGrants({
         ...query,
         order: query.direction,
-        order_by: (query.grantOrder === 'title' || !query.grantOrder) ? 'title.raw' : query.grantOrder,
+        order_by: (query.grantSort === 'title' || !query.grantSort) ? 'title.raw' : query.grantSort,
         start: query.grantDialogYear ?? query.start,
         end: query.grantDialogYear ?? query.end,
         divisions: query.grantDialogDivision ? [query.grantDialogDivision] : query.divisions,

--- a/frontend/src/app/grants/grantsDownload.ts
+++ b/frontend/src/app/grants/grantsDownload.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'app/query';
+import { DefaultService as Service } from '../../api/index';
+
+const useGrantsDownload = () => {
+  const [ query ] = useQuery();
+
+  return async () => {
+    const data = await Service.downloadGrants({
+      ...query,
+      order: query.grantDirection,
+      order_by: query.grantSort === 'title' ? 'title.raw' : query.grantSort ?? 'title.raw',
+      start: query.grantDialogYear ?? query.start,
+      end: query.grantDialogYear ?? query.end,
+      divisions: query.grantDialogDivision ? [query.grantDialogDivision] : query.divisions,
+      idx: 0,
+    });
+    const blob = new Blob([data]);
+    const link = document.createElement('a');
+    link.href = window.URL.createObjectURL(blob);
+    link.download = 'grants.csv';
+    link.click();
+  };
+};
+
+export default useGrantsDownload;

--- a/frontend/src/app/nav/Actions.tsx
+++ b/frontend/src/app/nav/Actions.tsx
@@ -1,30 +1,32 @@
 import { Link, SpeedDial, SpeedDialAction, SpeedDialIcon } from '@material-ui/core';
 import { GitHub, GridOn, InsertDriveFile } from '@mui/icons-material';
-
-const actions = [
-  {
-    name: 'Download Tabular Data',
-    icon: <GridOn />,
-    href: ''
-  },
-  {
-    name: 'Download Grant Data',
-    icon: <InsertDriveFile />,
-    href: ''
-  },
-  {
-    name: 'View Source',
-    icon: <GitHub />,
-    href: 'https://github.com/jessecoleman/nsf-viz'
-  }
-];
-
+import useGrantsDownload from 'app/grants/grantsDownload';
 
 const Actions = () => {
-  
+
+  const handleDownloadGrants = useGrantsDownload();
+
+  const actions = [
+    {
+      name: 'Download Tabular Data',
+      icon: <GridOn />,
+      href: ''
+    },
+    {
+      name: 'Download Grant Data',
+      icon: <InsertDriveFile />,
+      onClick: handleDownloadGrants,
+    },
+    {
+      name: 'View Source',
+      icon: <GitHub />,
+      href: 'https://github.com/jessecoleman/nsf-viz'
+    }
+  ];
+ 
   return (
     <SpeedDial
-      ariaLabel="SpeedDial basic example"
+      ariaLabel='external links'
       sx={{ position: 'absolute', bottom: 16, right: 16 }}
       icon={<SpeedDialIcon />}
     >
@@ -33,6 +35,7 @@ const Actions = () => {
           key={action.name}
           icon={<Link href={action.href}>{action.icon}</Link>}
           tooltipTitle={action.name}
+          onClick={action.onClick}
         />
       ))}
     </SpeedDial>

--- a/frontend/src/app/nav/Actions.tsx
+++ b/frontend/src/app/nav/Actions.tsx
@@ -7,11 +7,11 @@ const Actions = () => {
   const handleDownloadGrants = useGrantsDownload();
 
   const actions = [
-    {
-      name: 'Download Tabular Data',
-      icon: <GridOn />,
-      href: ''
-    },
+    // {
+    //   name: 'Download Tabular Data',
+    //   icon: <GridOn />,
+    //   href: ''
+    // },
     {
       name: 'Download Grant Data',
       icon: <InsertDriveFile />,

--- a/frontend/src/app/query.ts
+++ b/frontend/src/app/query.ts
@@ -38,23 +38,25 @@ const MatchParam = withDefault(
   ['title', 'abstract']
 ) as QueryParamConfig<Array<'title' | 'abstract'>>;
 
+export const paramConfigMap = {
+  'org': OrgParam,
+  'terms': ArrayParam,
+  'divisions': ArrayParam,
+  'start': DefaultNumberParam,
+  'end': DefaultNumberParam,
+  'intersection': DefaultBooleanParam,
+  'match': MatchParam,
+  'sort': SortParam,
+  'direction': SortDirectionParam,
+  'grantDialogOpen': BooleanParam,
+  'grantDialogYear': NumberParam,
+  'grantDialogDivision': StringParam,
+  'grantSort': StringParam,
+  'grantDirection': SortDirectionParam,
+};
+
 export const useQuery = () => (
-  useQueryParams({
-    'org': OrgParam,
-    'terms': ArrayParam,
-    'divisions': ArrayParam,
-    'start': DefaultNumberParam,
-    'end': DefaultNumberParam,
-    'intersection': DefaultBooleanParam,
-    'match': MatchParam,
-    'sort': SortParam,
-    'direction': SortDirectionParam,
-    'grantDialogOpen': BooleanParam,
-    'grantDialogYear': NumberParam,
-    'grantDialogDivision': StringParam,
-    'grantOrder': StringParam,
-    'grantDirection': SortDirectionParam,
-  })
+  useQueryParams(paramConfigMap)
 );
 
 export type QueryParams = ReturnType<typeof useQuery>[0];

--- a/orval.config.js
+++ b/orval.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    grants: {
+        input: {
+            target: './backend/api.json',
+        },
+        output: {
+            target: './frontend/src/api.ts',
+            client: 'react-query',
+            baseURL: 'http://localhost:8888'
+        },
+    }
+};


### PR DESCRIPTION
I accidentally corrupted and closed the original of this PR, so I'm reopening it. Here was the original description written by Cole:

Users can download grant data either from the speed dial button in the bottom right of the screen, or the download button in the grant dialog popup. Currently limited to 10,000 grants at a time (this is a hard limit set by Elasticsearch) but can discuss what a sensible limit should be.