### PR TITLE
add links to external urls in the abstract dialog box

### DIFF
--- a/backend/ingest_data/index_grants.py
+++ b/backend/ingest_data/index_grants.py
@@ -73,6 +73,7 @@ class Grant(Document):
     cat2_raw = Keyword()
     cat3 = Keyword()
     cat3_raw = Keyword()
+    external_url = Keyword()
 
 
 def format_date(date_str: str) -> str:
@@ -126,6 +127,7 @@ def get_data(data_source: Iterable) -> Generator:
                 cat1=mapped_abbrev,
                 cat2=nsf_directory_inv.get(mapped_abbrev, mapped_abbrev),
                 agency=r["agency"],
+                external_url=r.get("external_url")
             )
             yield g.to_dict(True)
         except KeyError:

--- a/backend/models.py
+++ b/backend/models.py
@@ -96,6 +96,7 @@ class Grant(BaseModel):
     cat2_raw: Optional[str]
     cat3: Optional[str]
     cat3_raw: Optional[str]
+    external_url: Optional[str]
 
 
 class Order(str, Enum):

--- a/frontend/src/app/grants/AbstractDialog.tsx
+++ b/frontend/src/app/grants/AbstractDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Collapse, Dialog, DialogActions, DialogContent, DialogTitle, LinearProgress, styled, Typography } from '@material-ui/core';
+import LaunchIcon from '@mui/icons-material/Launch';
 import { useLoadAbstract } from 'api';
 import { useGrantIdQuery, useQuery } from 'app/query';
 import * as d3 from 'd3';
@@ -51,7 +52,12 @@ const AbstractDialog = () => {
       {grant && (
         <>
           <DialogTitle>
-            <Title variant='h5'>{grant.title}</Title>
+            <Title variant='h5'>
+              {grant.title}
+              {grant.external_url ? (
+                <a href={grant.external_url} target="_blank" rel="noreferrer"><LaunchIcon /></a>
+              ) : null}
+            </Title>
             <Subtitle variant='h6'>{grant.cat1_raw}</Subtitle>
             <Subtitle variant='h6'>{timeConvert(grant.date)}</Subtitle>
             <Subtitle variant='h6'>{d3.format('$,')(grant.amount)}</Subtitle>

--- a/frontend/src/app/grants/AbstractDialog.tsx
+++ b/frontend/src/app/grants/AbstractDialog.tsx
@@ -54,9 +54,9 @@ const AbstractDialog = () => {
           <DialogTitle>
             <Title variant='h5'>
               {grant.title}
-              {grant.external_url ? (
+              {grant.external_url && (
                 <a href={grant.external_url} target="_blank" rel="noreferrer"><LaunchIcon /></a>
-              ) : null}
+              )}
             </Title>
             <Subtitle variant='h6'>{grant.cat1_raw}</Subtitle>
             <Subtitle variant='h6'>{timeConvert(grant.date)}</Subtitle>


### PR DESCRIPTION
There's a new field in the data for "external_url": the url to either the NSF or NIH page for the grant. (This isn't really possible for DoD grants).

These changes update the elasticsearch and pydantic models with this field, and add a link in the grant abstract dialog.