### PR TITLE
add recipient org name and PI names

### DIFF
--- a/backend/ingest_data/index_grants.py
+++ b/backend/ingest_data/index_grants.py
@@ -23,7 +23,12 @@ import logging
 root_logger = logging.getLogger()
 logger = root_logger.getChild(__name__)
 
-from parse_abbrevs import abbrevs_flat, normalize, nsf_mapped_reversed, nsf_directory_inv
+from parse_abbrevs import (
+    abbrevs_flat,
+    normalize,
+    nsf_mapped_reversed,
+    nsf_directory_inv,
+)
 
 host = os.environ.get("ELASTICSEARCH_HOST", "localhost")
 es = connections.create_connection(hosts=[host], timeout=20)
@@ -74,6 +79,8 @@ class Grant(Document):
     cat3 = Keyword()
     cat3_raw = Keyword()
     external_url = Keyword()
+    investigators = Keyword()
+    recipient_org = Keyword()
 
 
 def format_date(date_str: str) -> str:
@@ -127,7 +134,9 @@ def get_data(data_source: Iterable) -> Generator:
                 cat1=mapped_abbrev,
                 cat2=nsf_directory_inv.get(mapped_abbrev, mapped_abbrev),
                 agency=r["agency"],
-                external_url=r.get("external_url")
+                external_url=r.get("external_url"),
+                investigators=r.get("investigators"),
+                recipient_org=r.get("recipient_org"),
             )
             yield g.to_dict(True)
         except KeyError:

--- a/backend/models.py
+++ b/backend/models.py
@@ -97,6 +97,8 @@ class Grant(BaseModel):
     cat3: Optional[str]
     cat3_raw: Optional[str]
     external_url: Optional[str]
+    investigators: Optional[str]
+    recipient_org: Optional[str]
 
 
 class Order(str, Enum):

--- a/frontend/src/app/divisions/DivisionToolbar.tsx
+++ b/frontend/src/app/divisions/DivisionToolbar.tsx
@@ -48,7 +48,7 @@ type DivisionToolbarProps = {
 
 const orgs = [
   { title: 'National Science Foundation', abbr: 'nsf', src: nsf },
-  { title: 'National Institute of Health', abbr: 'nih', src: nih },
+  { title: 'National Institutes of Health', abbr: 'nih', src: nih },
   { title: 'Department of Defense', abbr: 'dod', src: dod}
 ];
 

--- a/frontend/src/app/grants/AbstractDialog.tsx
+++ b/frontend/src/app/grants/AbstractDialog.tsx
@@ -61,6 +61,12 @@ const AbstractDialog = () => {
             <Subtitle variant='h6'>{grant.cat1_raw}</Subtitle>
             <Subtitle variant='h6'>{timeConvert(grant.date)}</Subtitle>
             <Subtitle variant='h6'>{d3.format('$,')(grant.amount)}</Subtitle>
+            {grant.recipient_org && (
+              <Subtitle variant='body2'>Recipient Organization: {grant.recipient_org}</Subtitle>
+            )}
+            {grant.investigators && (
+              <Subtitle variant='body2'>Principal Investigator(s): {grant.investigators}</Subtitle>
+            )}
           </DialogTitle>
           <DialogContent>
             <Collapse in={!!grant.abstract}>


### PR DESCRIPTION
There are two new string fields in the data, one for recipient organization, and one for PI names.

This adds this info to the abstract dialog.

Feel free to make changes if you want it to look a different way. Here's an example of how it looks:

![image](https://user-images.githubusercontent.com/11617736/155640210-84b8fc48-81fb-4595-8407-cc5d06efba56.png)
